### PR TITLE
Add optional 'Log in with Authelia' OIDC to admin login

### DIFF
--- a/cloud-server/.env.example
+++ b/cloud-server/.env.example
@@ -13,3 +13,14 @@ PORT=3001
 # Initial admin credentials (only used on first run when no users exist)
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=change_me_immediately
+
+# ── Optional: "Log in with Authelia" OIDC (additive; password login always works) ──
+# Set OIDC_CLIENT_SECRET to enable the extra "Log in with Authelia" button on the
+# admin login page. Leave it unset to disable OIDC entirely (the button/routes turn
+# off and the app runs with username/password login only).
+# The three non-secret values below default to the production Authelia client, so in
+# most deployments you only need to set OIDC_CLIENT_SECRET.
+OIDC_ISSUER=https://auth.filipkin.com
+OIDC_CLIENT_ID=captions
+OIDC_CLIENT_SECRET=
+OIDC_REDIRECT_URI=https://captions.filipkin.com/admin/oidc/callback

--- a/cloud-server/src/admin/pages/Login.tsx
+++ b/cloud-server/src/admin/pages/Login.tsx
@@ -1,12 +1,48 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { trpc, setToken } from '../api';
+
+const OIDC_ERROR_MESSAGES: Record<string, string> = {
+    oidc_disabled: 'Authelia login is not configured.',
+    oidc_denied: 'Authelia login was cancelled.',
+    oidc_state: 'Authelia login expired. Please try again.',
+    oidc_forbidden: 'Your Authelia account is not an admin.',
+    oidc_failed: 'Authelia login failed. Please try again.',
+};
 
 export function Login() {
     const navigate = useNavigate();
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [error, setError] = useState('');
+
+    const oidcEnabled = trpc.admin.oidcEnabled.useQuery(undefined, {
+        staleTime: Infinity,
+        retry: false,
+    });
+
+    // Handle the OIDC callback handoff: the server redirects here with the freshly
+    // minted admin JWT in the URL fragment (never sent to the server). Store it the
+    // same way the password login does, then continue into the panel. Also surface
+    // any ?error= reported by the OIDC callback.
+    useEffect(() => {
+        const hash = window.location.hash;
+        const tokenMatch = hash.match(/token=([^&]+)/);
+        if (tokenMatch) {
+            const token = decodeURIComponent(tokenMatch[1]);
+            // Strip the token from the URL before navigating.
+            window.history.replaceState(null, '', window.location.pathname + window.location.search);
+            setToken(token);
+            navigate('/admin/');
+            return;
+        }
+        const params = new URLSearchParams(window.location.search);
+        const err = params.get('error');
+        if (err) {
+            setError(OIDC_ERROR_MESSAGES[err] ?? 'Login failed. Please try again.');
+            window.history.replaceState(null, '', window.location.pathname);
+        }
+    }, [navigate]);
 
     const login = trpc.admin.login.useMutation({
         onSuccess: (data) => {
@@ -56,6 +92,22 @@ export function Login() {
                         {login.isPending ? 'Signing in...' : 'Sign in'}
                     </button>
                 </form>
+
+                {oidcEnabled.data?.enabled && (
+                    <>
+                        <div className="flex items-center gap-3 my-6">
+                            <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+                            <span className="text-xs text-gray-400 uppercase tracking-wide">or</span>
+                            <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+                        </div>
+                        <a
+                            href="/admin/oidc/login"
+                            className="block w-full text-center border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded px-4 py-2 text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                        >
+                            Log in with Authelia
+                        </a>
+                    </>
+                )}
             </div>
         </div>
     );

--- a/cloud-server/src/auth/oidc.ts
+++ b/cloud-server/src/auth/oidc.ts
@@ -1,0 +1,280 @@
+import { randomBytes, createHash, createHmac, timingSafeEqual } from 'crypto';
+import type { Express, Request, Response } from 'express';
+import { eq } from 'drizzle-orm';
+import { db, schema } from '../db';
+import { getJwtSecret, signAdminToken } from './index';
+
+// #region config
+// Additive "Log in with Authelia" OIDC (authorization-code + PKCE, client_secret_post).
+// This lives entirely alongside the existing username/password login. When
+// OIDC_CLIENT_SECRET is unset the whole feature is disabled and the app keeps
+// running with password login only.
+
+const OIDC_ISSUER = process.env.OIDC_ISSUER ?? 'https://auth.filipkin.com';
+const OIDC_CLIENT_ID = process.env.OIDC_CLIENT_ID ?? 'captions';
+const OIDC_REDIRECT_URI =
+    process.env.OIDC_REDIRECT_URI ?? 'https://captions.filipkin.com/admin/oidc/callback';
+const OIDC_SCOPES = 'openid profile email groups';
+const REQUIRED_GROUP = 'admins';
+const TX_COOKIE = 'oidc_tx';
+const TX_TTL_MS = 10 * 60 * 1000; // 10 minutes to complete the round-trip
+
+function clientSecret(): string | undefined {
+    return process.env.OIDC_CLIENT_SECRET;
+}
+
+/** True when the operator has configured an OIDC client secret. */
+export function isOidcEnabled(): boolean {
+    return !!clientSecret();
+}
+// #endregion
+
+// #region discovery
+interface OidcEndpoints {
+    authorization_endpoint: string;
+    token_endpoint: string;
+    userinfo_endpoint: string;
+}
+
+// Sensible fallbacks matching the Authelia deployment, used if discovery fails.
+const FALLBACK_ENDPOINTS: OidcEndpoints = {
+    authorization_endpoint: `${OIDC_ISSUER}/api/oidc/authorization`,
+    token_endpoint: `${OIDC_ISSUER}/api/oidc/token`,
+    userinfo_endpoint: `${OIDC_ISSUER}/api/oidc/userinfo`,
+};
+
+let cachedEndpoints: OidcEndpoints | null = null;
+
+async function getEndpoints(): Promise<OidcEndpoints> {
+    if (cachedEndpoints) return cachedEndpoints;
+    try {
+        const res = await fetch(`${OIDC_ISSUER}/.well-known/openid-configuration`);
+        if (res.ok) {
+            const doc = (await res.json()) as Partial<OidcEndpoints>;
+            if (doc.authorization_endpoint && doc.token_endpoint && doc.userinfo_endpoint) {
+                cachedEndpoints = {
+                    authorization_endpoint: doc.authorization_endpoint,
+                    token_endpoint: doc.token_endpoint,
+                    userinfo_endpoint: doc.userinfo_endpoint,
+                };
+                return cachedEndpoints;
+            }
+        }
+        console.warn('[oidc] Discovery document incomplete; using fallback endpoints');
+    } catch (err) {
+        console.warn('[oidc] Discovery failed; using fallback endpoints:', err);
+    }
+    cachedEndpoints = FALLBACK_ENDPOINTS;
+    return cachedEndpoints;
+}
+// #endregion
+
+// #region pkce + signed transaction cookie
+function base64url(buf: Buffer): string {
+    return buf.toString('base64url');
+}
+
+interface TxState {
+    state: string;
+    codeVerifier: string;
+    ts: number;
+}
+
+function signTx(payload: TxState): string {
+    const data = base64url(Buffer.from(JSON.stringify(payload)));
+    const sig = createHmac('sha256', getJwtSecret()).update(data).digest('base64url');
+    return `${data}.${sig}`;
+}
+
+function verifyTx(token: string | undefined): TxState | null {
+    if (!token) return null;
+    const dot = token.lastIndexOf('.');
+    if (dot < 0) return null;
+    const data = token.slice(0, dot);
+    const sig = token.slice(dot + 1);
+    const expected = createHmac('sha256', getJwtSecret()).update(data).digest('base64url');
+    const sigBuf = Buffer.from(sig);
+    const expBuf = Buffer.from(expected);
+    if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) return null;
+    try {
+        const payload = JSON.parse(Buffer.from(data, 'base64url').toString('utf8')) as TxState;
+        if (typeof payload.ts !== 'number' || Date.now() - payload.ts > TX_TTL_MS) return null;
+        if (!payload.state || !payload.codeVerifier) return null;
+        return payload;
+    } catch {
+        return null;
+    }
+}
+
+function readCookie(req: Request, name: string): string | undefined {
+    const header = req.headers.cookie;
+    if (!header) return undefined;
+    for (const part of header.split(';')) {
+        const idx = part.indexOf('=');
+        if (idx < 0) continue;
+        if (part.slice(0, idx).trim() === name) {
+            return decodeURIComponent(part.slice(idx + 1).trim());
+        }
+    }
+    return undefined;
+}
+
+const COOKIE_PATH = '/admin/oidc';
+
+function setTxCookie(res: Response, value: string): void {
+    res.cookie(TX_COOKIE, value, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        path: COOKIE_PATH,
+        maxAge: TX_TTL_MS,
+    });
+}
+
+function clearTxCookie(res: Response): void {
+    res.clearCookie(TX_COOKIE, { path: COOKIE_PATH });
+}
+// #endregion
+
+// #region routes
+function loginErrorRedirect(res: Response, code: string): void {
+    res.redirect(`/admin/login?error=${encodeURIComponent(code)}`);
+}
+
+async function handleLogin(_req: Request, res: Response): Promise<void> {
+    if (!isOidcEnabled()) return loginErrorRedirect(res, 'oidc_disabled');
+
+    const codeVerifier = base64url(randomBytes(32));
+    const codeChallenge = base64url(createHash('sha256').update(codeVerifier).digest());
+    const state = base64url(randomBytes(16));
+
+    setTxCookie(res, signTx({ state, codeVerifier, ts: Date.now() }));
+
+    const { authorization_endpoint } = await getEndpoints();
+    const params = new URLSearchParams({
+        response_type: 'code',
+        client_id: OIDC_CLIENT_ID,
+        redirect_uri: OIDC_REDIRECT_URI,
+        scope: OIDC_SCOPES,
+        state,
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+    });
+    res.redirect(`${authorization_endpoint}?${params.toString()}`);
+}
+
+async function handleCallback(req: Request, res: Response): Promise<void> {
+    if (!isOidcEnabled()) return loginErrorRedirect(res, 'oidc_disabled');
+
+    // The transaction cookie is single-use regardless of outcome.
+    const tx = verifyTx(readCookie(req, TX_COOKIE));
+    clearTxCookie(res);
+
+    try {
+        const { code, state, error } = req.query as Record<string, string | undefined>;
+        if (error) return loginErrorRedirect(res, 'oidc_denied');
+        if (!code || !state) return loginErrorRedirect(res, 'oidc_failed');
+        if (!tx || tx.state !== state) return loginErrorRedirect(res, 'oidc_state');
+
+        const { token_endpoint, userinfo_endpoint } = await getEndpoints();
+
+        // Exchange the authorization code (client_secret_post + PKCE verifier).
+        const tokenRes = await fetch(token_endpoint, {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                grant_type: 'authorization_code',
+                code,
+                redirect_uri: OIDC_REDIRECT_URI,
+                client_id: OIDC_CLIENT_ID,
+                client_secret: clientSecret() as string,
+                code_verifier: tx.codeVerifier,
+            }).toString(),
+        });
+        if (!tokenRes.ok) {
+            console.warn('[oidc] Token exchange failed:', tokenRes.status, await safeText(tokenRes));
+            return loginErrorRedirect(res, 'oidc_failed');
+        }
+        const tokens = (await tokenRes.json()) as { access_token?: string };
+        if (!tokens.access_token) return loginErrorRedirect(res, 'oidc_failed');
+
+        // Fetch userinfo to authorize and identify the admin.
+        const userinfoRes = await fetch(userinfo_endpoint, {
+            headers: { authorization: `Bearer ${tokens.access_token}` },
+        });
+        if (!userinfoRes.ok) {
+            console.warn('[oidc] Userinfo failed:', userinfoRes.status);
+            return loginErrorRedirect(res, 'oidc_failed');
+        }
+        const userinfo = (await userinfoRes.json()) as {
+            groups?: string[];
+            email?: string;
+            preferred_username?: string;
+        };
+
+        // Defense in depth: the client is restricted to group:admins server-side,
+        // but re-check here before minting a session.
+        const groups = Array.isArray(userinfo.groups) ? userinfo.groups : [];
+        if (!groups.includes(REQUIRED_GROUP)) {
+            console.warn('[oidc] Rejecting login: user not in required group');
+            return loginErrorRedirect(res, 'oidc_forbidden');
+        }
+
+        // Match to an existing local admin record by preferred_username / email
+        // (or email local-part) so the minted JWT is identical to a password login.
+        // If none matches, the user is still an authorized org admin: mint the
+        // session anyway with a synthetic id, and do NOT create/alter any user row.
+        const adminId = await resolveAdminId(userinfo.preferred_username, userinfo.email);
+
+        // Mint the SAME admin JWT the password login mints, then hand it to the
+        // SPA via the URL fragment (never sent to the server / never logged).
+        const token = signAdminToken(adminId);
+        res.redirect(`/admin/login#token=${encodeURIComponent(token)}`);
+    } catch (err) {
+        console.warn('[oidc] Callback error:', err);
+        return loginErrorRedirect(res, 'oidc_failed');
+    }
+}
+
+async function resolveAdminId(
+    preferredUsername: string | undefined,
+    email: string | undefined,
+): Promise<number> {
+    const candidates = new Set<string>();
+    if (preferredUsername) candidates.add(preferredUsername);
+    if (email) {
+        candidates.add(email);
+        const local = email.split('@')[0];
+        if (local) candidates.add(local);
+    }
+    for (const username of candidates) {
+        const user = await db.query.users.findFirst({
+            where: eq(schema.users.username, username),
+        });
+        if (user) return user.id;
+    }
+    // No local record. Authorized admins-group user with no password account.
+    // Negative id can never collide with a serial user id, keeping the
+    // self-delete guard and any id-based lookups safe.
+    return -1;
+}
+
+async function safeText(res: globalThis.Response): Promise<string> {
+    try {
+        return (await res.text()).slice(0, 500);
+    } catch {
+        return '<no body>';
+    }
+}
+
+/** Register the additive OIDC login routes. Must be mounted before the
+ *  /admin static + SPA catch-all so these paths are handled server-side. */
+export function registerOidcRoutes(app: Express): void {
+    app.get('/admin/oidc/login', (req, res) => {
+        handleLogin(req, res).catch(() => loginErrorRedirect(res, 'oidc_failed'));
+    });
+    app.get('/admin/oidc/callback', (req, res) => {
+        handleCallback(req, res).catch(() => loginErrorRedirect(res, 'oidc_failed'));
+    });
+}
+// #endregion

--- a/cloud-server/src/server.ts
+++ b/cloud-server/src/server.ts
@@ -10,6 +10,7 @@ import { createRouter } from './trpc/router';
 import { createContext } from './trpc/context';
 import { relay } from './relay';
 import { hashDeviceToken, verifyAdminToken } from './auth';
+import { registerOidcRoutes } from './auth/oidc';
 import { db, schema } from './db';
 import { eq } from 'drizzle-orm';
 
@@ -29,6 +30,11 @@ export function createServer() {
             }
         },
     }));
+
+    // Additive "Log in with Authelia" OIDC routes. Registered before the /admin
+    // static + SPA catch-all so they are handled server-side. Disabled (routes
+    // redirect back to the login page) when OIDC_CLIENT_SECRET is unset.
+    registerOidcRoutes(app);
 
     // Serve admin panel static files
     const adminDir = path.join(__dirname, 'public', 'admin');

--- a/cloud-server/src/trpc/router.ts
+++ b/cloud-server/src/trpc/router.ts
@@ -11,6 +11,7 @@ import {
     decryptApiKey,
     getEncryptionKey,
 } from '../auth';
+import { isOidcEnabled } from '../auth/oidc';
 import { Context } from './context';
 import { relay } from '../relay';
 import {
@@ -147,6 +148,10 @@ export function createRouter() {
 
         // --- Admin routes ---
         admin: t.router({
+            // Lets the login page show the "Log in with Authelia" button only
+            // when OIDC is configured. Does not affect password login.
+            oidcEnabled: publicProcedure.query(() => ({ enabled: isOidcEnabled() })),
+
             login: publicProcedure
                 .input(z.object({ username: z.string(), password: z.string() }))
                 .mutation(async ({ input }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "live-captions",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "main": "./build/index.js",
     "bin": "./build/index.js",
     "scripts": {


### PR DESCRIPTION
## Summary
Adds an **additive** "Log in with Authelia" OpenID Connect option to the cloud-server admin login (captions.filipkin.com). The existing username/password login is **completely unchanged** and remains the default for all users who are not in the Authelia `admins` group. OIDC is an extra button, not a replacement.

Uses the authorization-code flow with **PKCE (S256)** and `client_secret_post`, verified against Authelia.

## What changed
- **`cloud-server/src/auth/oidc.ts`** (new) — the whole feature:
  - `GET /admin/oidc/login`: generates a PKCE verifier/challenge + random state, stashes them in a short-lived HMAC-signed `httpOnly`/`Secure`/`SameSite=Lax` cookie (signed with the existing `JWT_SECRET`), and redirects to Authelia's authorization endpoint.
  - `GET /admin/oidc/callback`: validates state, exchanges the code at the token endpoint (client_id + client_secret in the POST body + PKCE `code_verifier`), fetches userinfo, requires the `admins` group (defense in depth), then mints the **same** admin JWT (`signAdminToken`) the password login mints and hands it to the SPA via the URL **fragment** (never sent to the server/logs). Any failure redirects back to `/admin/login?error=…` — it never falls through to an authenticated state.
  - Endpoints are resolved via OIDC discovery with static fallbacks.
  - The admin is matched to an existing local user by `preferred_username` / `email` / email local-part so the JWT is byte-identical to a password login; if no local record exists the user is still an authorized org admin and gets a session with a synthetic id (no user row is created or altered).
- **`cloud-server/src/server.ts`** — registers the two OIDC routes before the `/admin` static + SPA catch-all.
- **`cloud-server/src/trpc/router.ts`** — adds a public `admin.oidcEnabled` query so the login page only shows the button when configured.
- **`cloud-server/src/admin/pages/Login.tsx`** — adds the "Log in with Authelia" button (shown only when enabled), reads the JWT handoff from the URL fragment and stores it exactly like the password login (`setToken`), and surfaces OIDC error messages.
- **`cloud-server/.env.example`** — documents the new env vars.

## Feature gating
The feature is gated on `OIDC_CLIENT_SECRET`. If it is unset, the button and routes are disabled and the app runs with password login only — a missing env can never break the password login.

## Env vars to set in Coolify (captions app)
```
OIDC_ISSUER=https://auth.filipkin.com
OIDC_CLIENT_ID=captions
OIDC_CLIENT_SECRET=<the Authelia client secret>
OIDC_REDIRECT_URI=https://captions.filipkin.com/admin/oidc/callback
```
Only `OIDC_CLIENT_SECRET` is strictly required; the other three default to these production values in code.

## Scope / safety
- Password/JWT/bcrypt login path is untouched.
- Device-token auth, device connect/stream endpoints, encrypted API keys, and display/caption output endpoints are not modified.
- No DB schema/migration changes; no user records created or altered.

## Testing
- `npm run build:server` (tsc) and `npm run build:admin` (vite) both pass clean.
- Drove both routes end-to-end with a stubbed Authelia + stubbed user lookup: login builds the correct PKCE/state authorize URL and sets the signed cookie; callback mints a valid admin JWT; state mismatch, missing cookie, provider error, and non-`admins`-group user are all rejected to the login page. (Harness not committed.)
- Not verified against the live Authelia instance — recommend a real login test after the env vars are set.